### PR TITLE
Add new :append_datetime param and fix dates to UTC.

### DIFF
--- a/lib/fastlane/plugin/changelog/actions/stamp_changelog.rb
+++ b/lib/fastlane/plugin/changelog/actions/stamp_changelog.rb
@@ -14,20 +14,22 @@ module Fastlane
           UI.important("WARNING: No changes in [Unreleased] section to stamp!")
         else
           section_identifier = params[:section_identifier] unless params[:section_identifier].to_s.empty?
-          stamp_date = params[:stamp_date]
+          stamp_date_time = params[:stamp_date_time]
+          stamp_date = params[:stamp_date_time] ? false : params[:stamp_date]
           git_tag = params[:git_tag]
           placeholder_line = params[:placeholder_line]
 
-          stamp(changelog_path, section_identifier, stamp_date, git_tag, placeholder_line)
+          stamp(changelog_path, section_identifier, stamp_date, stamp_date_time, git_tag, placeholder_line)
         end
       end
 
-      def self.stamp(changelog_path, section_identifier, stamp_date, git_tag, placeholder_line)
+      def self.stamp(changelog_path, section_identifier, stamp_date, stamp_date_time, git_tag, placeholder_line)
         # 1. Update [Unreleased] section with given identifier
         Actions::UpdateChangelogAction.run(changelog_path: changelog_path,
                                           section_identifier: UNRELEASED_IDENTIFIER,
                                           updated_section_identifier: section_identifier,
                                           append_date: stamp_date,
+                                          append_date_time: stamp_date_time,
                                           excluded_placeholder_line: placeholder_line)
 
         file_content = ""
@@ -131,8 +133,15 @@ module Fastlane
                                        is_string: true),
           FastlaneCore::ConfigItem.new(key: :stamp_date,
                                        env_name: "FL_STAMP_CHANGELOG_SECTION_STAMP_DATE",
-                                       description: "Specifies whether the current date should be appended to section identifier",
+                                       description: "Specifies whether the current UTC date should be appended to section identifier",
                                        default_value: true,
+                                       is_string: false,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :stamp_date_time,
+                                       env_name: "FL_STAMP_CHANGELOG_SECTION_STAMP_DATE_TIME",
+                                       description: "Specifies whether the current UTC date and time should be appended to section identifier",
+                                       default_value: false,
+                                       is_string: false,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :git_tag,
                                        env_name: "FL_STAMP_CHANGELOG_GIT_TAG",

--- a/lib/fastlane/plugin/changelog/actions/update_changelog.rb
+++ b/lib/fastlane/plugin/changelog/actions/update_changelog.rb
@@ -48,8 +48,15 @@ module Fastlane
               line_old = line.dup
               line.sub!(section_name, new_section_identifier)
 
-              if params[:append_date]
-                now = Time.now.strftime("%Y-%m-%d")
+              if params[:append_date_time] || params[:append_date]
+                if params[:append_date_time]
+                  now = Time.now.utc.iso8601
+                  ENV["FL_UPDATE_APPEND_DATE_TIME_VAL"] = now
+                else
+                  now = Time.now.utc.strftime("%Y-%m-%d")
+                  ENV["FL_UPDATE_APPEND_DATE_VAL"] = now
+                end
+
                 line.concat(" - " + now)
                 line.delete!(line_separator) # remove line break, because concatenation adds line break between section identifer & date
                 line.concat(line_separator) # add line break to the end of the string, in order to start next line on the next line
@@ -116,8 +123,14 @@ module Fastlane
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :append_date,
                                        env_name: "FL_UPDATE_CHANGELOG_APPEND_DATE",
-                                       description: "Appends the current date in YYYY-MM-DD format after the section identifier",
+                                       description: "Appends the current UTC date in YYYY-MM-DD format after the section identifier",
                                        default_value: true,
+                                       is_string: false,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :append_date_time,
+                                       env_name: "FL_UPDATE_CHANGELOG_APPEND_DATE_TIME",
+                                       description: "Appends the current UTC date in YYYY-MM-DDTHH:MM:SSZ format after the section identifier",
+                                       default_value: false,
                                        is_string: false,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :excluded_placeholder_line,

--- a/lib/fastlane/plugin/changelog/version.rb
+++ b/lib/fastlane/plugin/changelog/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Changelog
-    VERSION = "0.15.0"
+    VERSION = "0.15.1"
   end
 end


### PR DESCRIPTION
----
This PR adds a new stamp_changelog action argument: stamp_date_time. Specifying true stamps the changelog in the format of standard iso8601 date time "2020-12-17T22:25:13Z". By default it is false and when true it overrides stamp_date. The date chosen, whether by specifying stamp_date: true or stamp_date_time: true are placed in the env variable FL_UPDATE_DATE_VAL, FL_UPDATE_DATE_TIME_VAL respectively.

It also fixes the error being given by fastlane that the stamp_date arg was not a string and makes all the dates used for the stamp_dates be in UTC time.